### PR TITLE
Fix  regexp

### DIFF
--- a/lib/Regexp/Common/Chess.pm
+++ b/lib/Regexp/Common/Chess.pm
@@ -19,7 +19,7 @@ my $piece     = '[KNBQR]';
 
 my $promotion = "x?${file}[18]=(?!K)$piece";
 my $pawnmove  = "(?:$file?x)?$file(?![18])$rank";
-my $stdmove   = "$piece$file?$rank?x?$file$rank";
+my $stdmove   = "$piece(?:$file|$rank)?x?$file$rank";
 my $castling  = "O-O(?:-O)?";
 
 pattern name => ['Chess' => 'SAN'],


### PR DESCRIPTION
Prevent match in cases of moves like "Ne5xg4" which are not valid. After a piece, only a file or a rank should be allowed but not both.